### PR TITLE
Proposed extension classes to support CDX properties (#672)

### DIFF
--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -17,7 +17,6 @@ For details of how NamespaceMap content is to be serialized please refer to gene
 
 Namespace maps support a variety of relevant use cases such as:
 
-<<<<<<< HEAD
 1) An SPDX content producer wishing to provide clarity of their serialization of an SPDX 2.X simple style collection where all content is newly minted and a single prefix-namespace is used.  The consumer of SPDX content wishes to preserve the name space mapping provided by such a producer.  In this case, the consumer would record the namespace map prefixes in the NamespaceMap such that subsequent serializations could reproduce the prefixes / namespaces in the native serialization format.
 2) An SPDX content producer wishing to maintain consistent prefix use and understanding across multiple different serialization formats of the produced content.
    For example, an SBOM producer wishes to share/publish the SBOM as JSON-LD and XML. The producer can specify the preferred prefix mappings in the native serialization format using information from a single Namespacemap accessible local to the producer.

--- a/model/Extension/Classes/CdxPropertiesExtension.md
+++ b/model/Extension/Classes/CdxPropertiesExtension.md
@@ -1,0 +1,20 @@
+SPDX-License-Identifier: Community-Spec-1.0
+# CdxPropertiesExtension
+
+## Summary
+A type of extension consisting of a list of name value pairs.
+
+## Description
+This extension provides a more structured extension using a name-value approach.
+Unlike key-value stores, cdxProperties support duplicate names, each potentially having different values. 
+This is intended to be compatible with the CycloneDX property `properties`.
+
+## Metadata
+- name: CdxPropertiesExtension
+- SubclassOf: Extension
+- Instantiability: Concrete
+
+## Properties
+- cdxProperty
+  - type: CdxPropertyEntry
+  - minCount: 1

--- a/model/Extension/Classes/CdxPropertyEntry.md
+++ b/model/Extension/Classes/CdxPropertyEntry.md
@@ -1,0 +1,28 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# CdxPropertyEntry
+
+## Summary
+
+A property name with an associated value.
+
+## Description
+
+Each CdxPropertyEntry  contains a name-value pair which maps the name to its associated value.
+Unlike key-value stores, cdxProperties support duplicate names, each potentially having different values. 
+This class can be used to implement CycloneDX compatible properties.
+
+## Metadata
+
+- name: CdxPropertyEntry
+- Instantiability: Concrete
+
+## Properties
+
+- cdxPropName
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+- cdxPropValue
+  - type: xsd:string
+  - maxCount: 1

--- a/model/Extension/Properties/cdxPropName.md
+++ b/model/Extension/Properties/cdxPropName.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# cdxPropName
+
+## Summary
+
+A name used in a CdxExtension name-value pair.
+
+## Description
+
+A cdxPropName is used in a CdxExtension name-value pair.
+Unlike key-value stores, cdxProperties support duplicate names, each potentially having different values. 
+
+## Metadata
+
+- name: cdxPropName
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Extension/Properties/cdxPropValue.md
+++ b/model/Extension/Properties/cdxPropValue.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# cdxPropValue
+
+## Summary
+
+A value used in a CdxExtension name-value pair.
+
+## Description
+
+A cdxPropValue is used in a CdxExtension name-value pair.
+Unlike key-value stores, cdxProperties support duplicate names, each potentially having different values. 
+
+## Metadata
+
+- name: cdxPropValue
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Extension/Properties/cdxProperty.md
+++ b/model/Extension/Properties/cdxProperty.md
@@ -1,0 +1,20 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# cdxProperty
+
+## Summary
+
+Provides a map of a property names to a values.
+
+## Description
+
+
+This field provides a mapping of a name to a value.
+This is intended to be compatible with the CycloneDX property "properties".
+Unlike key-value stores, properties support duplicate names, each potentially having different values. 
+
+## Metadata
+
+- name: cdxProperty
+- Nature: ObjectProperty
+- Range: CdxPropertyEntry


### PR DESCRIPTION
* Proposed extension classes to support CDX properties



* Update extension proposal per feedback



* Remove extraneous line in NamespaceMap



* Change cdxProperties to cdxProperty



* Add back seperate class for cdxPropertyEntry

Resolves feedback from Steve that the CDX properties are not key/value pairs but rather a mapping that allows duplication of property names with different values



---------